### PR TITLE
DBAAS-1091 - random root password fix

### DIFF
--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -121,7 +121,12 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 
 		if [ ! -z "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
-			export MARIADB_ROOT_PASSWORD="$(pwgen -1 32)"
+            # we have to filter characters like ' and \ that will terminate the sql query or don't count
+            # as special characters to keep the enterprise server password policy in mind.
+            MARIADB_ROOT_PASSWORD="'"
+            while [[ $MARIADB_ROOT_PASSWORD == *"'"* ]] || [[ $MARIADB_ROOT_PASSWORD == *"\\"* ]]; do
+			    export MARIADB_ROOT_PASSWORD="$(pwgen -1 32 -y)"
+            done
 			echo "GENERATED ROOT PASSWORD: $MARIADB_ROOT_PASSWORD"
 		fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,7 +121,12 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 
 		if [ ! -z "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
-			export MARIADB_ROOT_PASSWORD="$(pwgen -1 32)"
+            # we have to filter characters like ' and \ that will terminate the sql query or don't count
+            # as special characters to keep the enterprise server password policy in mind.
+            MARIADB_ROOT_PASSWORD="'"
+            while [[ $MARIADB_ROOT_PASSWORD == *"'"* ]] || [[ $MARIADB_ROOT_PASSWORD == *"\\"* ]]; do
+			    export MARIADB_ROOT_PASSWORD="$(pwgen -1 32 -y)"
+            done
 			echo "GENERATED ROOT PASSWORD: $MARIADB_ROOT_PASSWORD"
 		fi
 


### PR DESCRIPTION
If the generated random root password contained a quotation mark ' it escaped the root user generation query. This fix generates a new random password if a quotation mark is detected.