### PR TITLE
TODO-2680: CS Docker images - transition to a single image

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -201,6 +201,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'MySQL init process done. Ready for start up.'
 		echo
 	fi
+	echo 'This image is deprecated and will be replaced by https://hub.docker.com/_/mariadb in the future.' >&2
 fi
 
 # Jemalloc

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Deprecated
+
+This image is deprecated and the focus of development will be on the [Docker Library Official Image](https://hub.docker.com/_/mariadb) (source: [mariadb-docker](https://github.com/MariaDB/mariadb-docker)).
+
+Please report any blocking incompatibilities that affect your transition on [JIRA](https://jira.mariadb.org/).
+
 ## Maintained by: [MariaDB](https://mariadb.com/)
 
 This is the Git repo of docker images for MariaDB Server, [mariadb-server-docker](https://github.com/mariadb-corporation/mariadb-server-docker)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -199,6 +199,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'MySQL init process done. Ready for start up.'
 		echo
 	fi
+	echo 'This image is deprecated and will be replaced by https://hub.docker.com/_/mariadb in the future.' >&2
 fi
 
 exec "$@"


### PR DESCRIPTION
As part of moving to a single image we need to deprecate this one.

Please merge entrypoint changes to other branches.